### PR TITLE
Simplify base URL logic and use constant for production domain

### DIFF
--- a/lib/url.ts
+++ b/lib/url.ts
@@ -1,12 +1,11 @@
+const DOMAIN = "sayethereum.fun"
+
 export const getBaseUrl = () => {
-  if (process.env.NEXT_PUBLIC_DOMAIN) {
-    // Production domain (if set)
-    return `https://${process.env.NEXT_PUBLIC_DOMAIN}`
+  if (process.env.NEXT_PUBLIC_VERCEL_TARGET_ENV === "production") {
+    return `https://${DOMAIN}`
   }
-  if (process.env.VERCEL_URL) {
-    // Vercel deployment (preview or production)
-    return `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
+  if (process.env.NEXT_PUBLIC_VERCEL_BRANCH_URL) {
+    return `https://${process.env.NEXT_PUBLIC_VERCEL_BRANCH_URL}`
   }
-  // Development
   return "http://localhost:3000"
 }


### PR DESCRIPTION
- Simplify base URL logic and use constant for production domain
### Rational

- production domain is fixed value and not confidential.
- it's simpler and visible to manage the value without third-party Vercel settings. 
