### PR TITLE
Return 200 status in stead of 304 for sitemap unread error by Google Search Console

### DIFF
--- a/serve.json
+++ b/serve.json
@@ -1,0 +1,21 @@
+{
+  "headers": [
+    {
+      "source": "/sitemap.xml",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-cache, no-store, must-revalidate"
+        },
+        {
+          "key": "Pragma",
+          "value": "no-cache"
+        },
+        {
+          "key": "Expires",
+          "value": "0"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
- Return 200 status in stead of 304 for sitemap unread error by Google Search Console